### PR TITLE
Silly update: fixes hyperlinks on the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,9 @@ TableLayout is a lightweight Java library for setting the position and size of U
 	- [Colspan](#colspan)
 - [Uniform](#uniform)
 - [Defaults](#defaults)
-- [Cell defaults](#cell-defaults)
-- [Column defaults](#column-defaults)
-- [Row defaults](#row-defaults)
+	- [Cell defaults](#cell-defaults)
+	- [Column defaults](#column-defaults)
+	- [Row defaults](#row-defaults)
 - [Stacks](#stacks)
 - [Similar libraries](#similar-libraries)
 


### PR DESCRIPTION
I'm guessing these worked at some point, probably on the google code repo, but they were broken for me tonight so I fixed them for github's auto-link creation. I also tabbed over the ones that are sub-headings to make it easier to read.

(Sorry for pushing from master to master; failed at branching and just went with it)
