### PR TITLE
Add Maven pom build configuration files

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <!--
+    Maven build configuration for distribution
+    -->
+
+    <groupId>com.esotericsoftware</groupId>
+    <artifactId>tablelayout-parent</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <packaging>pom</packaging>
+
+    <name>tablelayout-parent</name>
+    <url>https://github.com/EsotericSoftware/tablelayout</url>
+
+    <description>
+        Table-based layout for Java UI toolkits: libgdx, Swing, Android, TWL
+    </description>
+
+    <inceptionYear>2011</inceptionYear>
+
+    <licenses>
+        <license>
+            <name>BSD 3-Clause "New" or "Revised" License</name>
+            <url>https://api.github.com/licenses/bsd-3-clause</url>
+            <distribution>repo</distribution>
+        </license>
+    </licenses>
+
+    <developers>
+        <developer>
+            <id>NathanSweet</id>
+            <name>Nathan Sweet</name>
+            <url>http://esotericsoftware.com</url>
+        </developer>
+    </developers>
+
+    <modules>
+        <module>tablelayout</module>
+        <module>tablelayout-swing</module>
+        <module>tablelayout-twl</module>
+        <module>tablelayout-android</module>
+    </modules>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <build>
+        <sourceDirectory>src</sourceDirectory>
+        <testSourceDirectory>test</testSourceDirectory>
+    </build>
+</project>

--- a/tablelayout-android/pom.xml
+++ b/tablelayout-android/pom.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0"?>
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>com.esotericsoftware</groupId>
+        <artifactId>tablelayout-parent</artifactId>
+        <version>1.0-SNAPSHOT</version>
+        <relativePath>../</relativePath>
+    </parent>
+
+    <artifactId>tablelayout-android</artifactId>
+
+    <name>tablelayout-android</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>tablelayout</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.google.android</groupId>
+            <artifactId>android</artifactId>
+            <version>2.0</version>
+            <scope>system</scope>
+            <systemPath>${project.basedir}/lib/android-2.0.jar</systemPath>
+        </dependency>
+    </dependencies>
+</project>

--- a/tablelayout-swing/pom.xml
+++ b/tablelayout-swing/pom.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0"?>
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>com.esotericsoftware</groupId>
+        <artifactId>tablelayout-parent</artifactId>
+        <version>1.0-SNAPSHOT</version>
+        <relativePath>../</relativePath>
+    </parent>
+
+    <artifactId>tablelayout-swing</artifactId>
+
+    <name>tablelayout-swing</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>tablelayout</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/tablelayout-twl/pom.xml
+++ b/tablelayout-twl/pom.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0"?>
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>com.esotericsoftware</groupId>
+        <artifactId>tablelayout-parent</artifactId>
+        <version>1.0-SNAPSHOT</version>
+        <relativePath>../</relativePath>
+    </parent>
+
+    <artifactId>tablelayout-twl</artifactId>
+
+    <name>tablelayout-twl</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>tablelayout</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>de.matthiasmann</groupId>
+            <artifactId>twl</artifactId>
+            <version>841</version>
+            <scope>system</scope>
+            <systemPath>${project.basedir}/lib/twl.jar</systemPath>
+        </dependency>
+
+        <dependency>
+            <groupId>org.lwjgl.lwjgl</groupId>
+            <artifactId>lwjgl</artifactId>
+            <version>2.9.3</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/tablelayout/pom.xml
+++ b/tablelayout/pom.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>com.esotericsoftware</groupId>
+        <artifactId>tablelayout-parent</artifactId>
+        <version>1.0-SNAPSHOT</version>
+        <relativePath>../</relativePath>
+    </parent>
+
+    <artifactId>tablelayout</artifactId>
+
+    <name>tablelayout</name>
+</project>


### PR DESCRIPTION
I often use TableLayout when working in swing, but the fact that it isn't distributed through any repository and that there are no pre-built artifacts makes it a bit annoying to include into my projects and to recommend it to others.

A way to fix this is to use [JitPack](https://jitpack.io), but JitPack requires build files. It would be possible to hook it up through custom script to use existing Scar build configuration, but it would probably end up being more complicated than this (unless Scar has some special support for things like this, but I haven't found anything).

This PR adds minimal Maven build scripts, which JitPack can use to generate artifacts on the fly. This is probably the simplest and most readable way to allow the whole thing to work. The build generates one library per backend, one core, and an aggregate dependency on everything (JitPack does this automatically, though it is probably of little value). You can see it in action [here](https://jitpack.io/#Darkyenus/tablelayout) (go to Branches -> jitpack).

The resulting dependency coordinate would look, for swing variant, like this: `com.github.EsotericSoftware.tablelayout:tablelayout-swing:jitpack-SNAPSHOT`. I can follow/extend this PR with a README update and possibly a JitPack badge.

The Maven build configuration does not replace any other build configuration files already present and is purely for Jitpack distribution.

Thanks for the great library!
